### PR TITLE
Patch to display minutes in format-stats.

### DIFF
--- a/src/taoensso/tufte.cljc
+++ b/src/taoensso/tufte.cljc
@@ -570,10 +570,11 @@
 (defn- ft [nanosecs]
   (let [ns (long nanosecs)] ; Truncate any fractionals
     (cond
-      (>= ns 1000000000) (str (enc/round2 (/ ns 1000000000))  "s") ; 1e9
-      (>= ns    1000000) (str (enc/round2 (/ ns    1000000)) "ms") ; 1e6
-      (>= ns       1000) (str (enc/round2 (/ ns       1000)) "μs") ; 1e3
-      :else              (str                ns              "ns"))))
+      (>= ns 60000000000) (str (enc/round2 (/ ns 60000000000))  "m")
+      (>= ns 1000000000)  (str (enc/round2 (/ ns  1000000000))  "s") ; 1e9
+      (>= ns    1000000)  (str (enc/round2 (/ ns     1000000)) "ms") ; 1e6
+      (>= ns       1000)  (str (enc/round2 (/ ns        1000)) "μs") ; 1e3
+      :else               (str                ns               "ns"))))
 
 (defn format-stats
   ([stats]


### PR DESCRIPTION
Display time in minutes when duration is >= 1 minute.

I have some computations that take hours. It is difficult to comprehend the output with the current maximum granularity of seconds.
